### PR TITLE
Update pkgIndex.tcl to support statically-loaded twapi

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -404,10 +404,8 @@ install-lib-binaries: binaries
 	    $(INSTALL_DATA) $(srcdir)/$$p $(DESTDIR)$(pkglibdir)/$$destp; \
 	  fi; \
 	done
-	@if test "x$(SHARED_BUILD)" = "x1"; then \
-	    echo " Install pkgIndex.tcl $(DESTDIR)$(pkglibdir)"; \
-	    $(INSTALL_DATA) pkgIndex.tcl $(DESTDIR)$(pkglibdir); \
-	fi
+	@echo " Install pkgIndex.tcl $(DESTDIR)$(pkglibdir)";
+	@$(INSTALL_DATA) pkgIndex.tcl $(DESTDIR)$(pkglibdir);
 
 #========================================================================
 # Install binary executables (e.g. .exe files and dependent .dll files)

--- a/pkgIndex.tcl.in
+++ b/pkgIndex.tcl.in
@@ -33,7 +33,10 @@ package ifneeded twapi_base @PACKAGE_VERSION@ \
         }
 
         if {!$dllFound} {
-            error "Could not locate TWAPI dll."
+            if {[catch {uplevel #0 [list load {} $package_init_name]}]} {
+                error "Could not locate TWAPI dll."
+            }
+            set path {}
         }
 
         # Load was successful


### PR DESCRIPTION
This change updates the Makefile to install pkgIndex.tcl for both shared and static builds, and updates pkgIndex.tcl to attempt to load the static library.